### PR TITLE
Fix missing/case-sensitive headers

### DIFF
--- a/Firmware/Esp32/Esp32.ino
+++ b/Firmware/Esp32/Esp32.ino
@@ -2,8 +2,8 @@
 #include <Wire.h>
 #include <WiFi.h>
 #include <cmath>
-#include "mapper.h"
-#include "Filter.h"
+#include <mapper.h>
+//#include "Filter.h"
 #include <TinyPICO.h>
 
 #include "haptics.h"

--- a/Firmware/Esp32/haptics.h
+++ b/Firmware/Esp32/haptics.h
@@ -9,7 +9,7 @@
 #include "tf_exp_spring.h"
 #include "tf_sin.h"
 #include "tf_click_2.h"
-#include "arduino.h"
+#include "Arduino.h"
 
 const int TABLE_RESOLUTION = 65535;
 const int MAX_TORQUE = 180;


### PR DESCRIPTION
Hey @MathiasKirkegaard92,

This pull request is to fix headers:
- case-sensitive (blocks compilation): `#include "Arduino.h"`
- missing and not needed (blocks compilation): `//#include "Filter.h"`
- installed as arduino library: `#include <mapper.h>`

Kind regards,
Christian